### PR TITLE
Add Test for Incorrect Definite Integral Issue

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1635,6 +1635,11 @@ def test_issue_15640_log_substitutions():
     F = -sqrt(pi)*erfc(sqrt(log(x)))/2 - sqrt(log(x))/x
     assert integrate(f, x) == F and F.diff(x) == f
 
+def test_issue_27675():
+    assert integrate(2.06*(x + 0.20)/(x + 0.34)**2,
+                     (x, 0, 1)) == 2.1922358936689497
+    assert integrate((x + 0.19)/(x + 0.37)**2,
+                     (x, 0, 1)) == 0.95396338801128411
 
 def test_issue_15509():
     from sympy.vector import CoordSys3D


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Added a test for issue #27675

#### Brief description of what is fixed or changed
Added a test which will check whether issue of wrong definite integrals has been fixed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*integrals
 *Adds test to check for issue fix
<!-- END RELEASE NOTES -->
